### PR TITLE
Improved German translation.

### DIFF
--- a/src/main/resources/assets/layout_blocks/lang/de_de.lang
+++ b/src/main/resources/assets/layout_blocks/lang/de_de.lang
@@ -6,4 +6,4 @@ item.layout_blocks.item_placer.name=LayoutBlock Platzierer
 gui.solid=Solide
 gui.nonsolid=Nicht Solide
 gui.break_one=Einen Block zerstören
-gui.break_all=Zusammenhängende Blöcke
+gui.break_all=Verbund zerstören


### PR DESCRIPTION
The German translation was missing a verb. I tried to improve the string while keeping its short length.